### PR TITLE
Fixed nginx php 7 fpm configuration

### DIFF
--- a/fs/etc/nginx/conf.d/default.conf
+++ b/fs/etc/nginx/conf.d/default.conf
@@ -12,7 +12,7 @@ server {
     # execute PHP scripts
     location ~ \.php$ {
         try_files      $uri =404;
-        fastcgi_pass   unix:/var/run/php7-fpm.sock;
+        fastcgi_pass   unix:/run/php/php7.0-fpm.sock;
         fastcgi_index  index.php;
         fastcgi_param  SCRIPT_FILENAME $document_root$fastcgi_script_name;
         include        fastcgi_params;


### PR DESCRIPTION
The nginx configuration had the wrong php7-fpm socket file. Fixed it.